### PR TITLE
Eliminate stairs Level 3

### DIFF
--- a/Assets/Scenes/Level3.unity
+++ b/Assets/Scenes/Level3.unity
@@ -10925,7 +10925,7 @@ MonoBehaviour:
   - target: {fileID: 357279928}
     active: 1
   - target: {fileID: 531476485}
-    active: 0
+    active: 1
   - target: {fileID: 637421679}
     active: 1
   previousBlock: {fileID: 0}

--- a/Assets/Scripts/RotationManager_Level3_Dest.cs
+++ b/Assets/Scripts/RotationManager_Level3_Dest.cs
@@ -10,7 +10,7 @@ public class RotationManager_Level3_Dest : MonoBehaviour
         Transform cubeToConnect2 = GameObject.Find("Cube (50)").transform;
         Transform cubeToConnect3 = GameObject.Find("Cube (48)").transform;
         //return if Transform not found
-        if (cubeToConnect1 == null )//|| cubeToConnect2 == null)
+        if (cubeToConnect1 == null || cubeToConnect2 == null)
         {
             Debug.Log("Cube not reachable");
             return;
@@ -21,14 +21,14 @@ public class RotationManager_Level3_Dest : MonoBehaviour
             cubeToConnect1.GetComponent<Walkable>().possiblePath[1].active = true;
             cubeToConnect2.GetComponent<Walkable>().possiblePath[1].active = true;
             cubeToConnect3.GetComponent<Walkable>().possiblePath[2].active = false;
-            //cubeToConnect2.GetComponent<Walkable>().canWalkOnThisBlock = true;
+            cubeToConnect1.GetComponent<Walkable>().possiblePath[2].active = false;
+            cubeToConnect1.GetComponent<Walkable>().canWalkOnThisBlock = true;
         }
         else
         {
             cubeToConnect1.GetComponent<Walkable>().possiblePath[1].active = false;
             cubeToConnect2.GetComponent<Walkable>().possiblePath[1].active = false;
-            cubeToConnect3.GetComponent<Walkable>().possiblePath[2].active = true;
-            //cubeToConnect2.GetComponent<Walkable>().canWalkOnThisBlock = false;
+            cubeToConnect1.GetComponent<Walkable>().canWalkOnThisBlock = false;
         }
     }
 }


### PR DESCRIPTION
I have removed the stairs from Level 3. Adjusted the possible paths accordingly so that player can walk on the rotate top block. Please check the player movement for any possible bugs. I have tested it for multiple scenarios as well.